### PR TITLE
Support wrapped cross-net message delivery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,7 @@ impl Actor {
                         "error creating fund cross-message",
                     )
                 })?,
+                wrapped: false,
             };
             // Commit top-down message.
             st.commit_topdown_msg(rt.store(), &mut f_msg).map_err(|e| {
@@ -522,6 +523,7 @@ impl Actor {
                             "error creating release cross-message",
                         )
                     })?,
+                wrapped: false,
             };
 
             // Commit bottom-up message.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,7 +616,7 @@ impl Actor {
     /// - Determines the type of cross-message.
     /// - Performs the corresponding state changes.
     /// - And updated the latest nonce applied for future checks.
-    fn apply_msg<BS, RT>(rt: &mut RT, params: StorableMsg) -> Result<(), ActorError>
+    fn apply_msg<BS, RT>(rt: &mut RT, params: ApplyMsgParams) -> Result<(), ActorError>
     where
         BS: Blockstore,
         RT: Runtime<BS>,
@@ -629,7 +629,7 @@ impl Actor {
         // picking up the whole state. Is it more efficient in terms of performance and
         // gas usage to check how to apply the message (b-u or t-p) inside rt.transaction?
         let st: State = rt.state()?;
-        let mut msg = params;
+        let mut msg = params.msg;
         let rto = match msg.to.raw_addr() {
             Ok(to) => to,
             Err(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use cross::CrossMsg;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::{
     actor_error, cbor, ActorDowncast, ActorError, BURNT_FUNDS_ACTOR_ADDR, INIT_ACTOR_ADDR,
@@ -455,12 +456,14 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             // Create fund message
-            let mut f_msg = StorableMsg::new_fund_msg(&params, &sig_addr, value).map_err(|e| {
-                e.downcast_default(
-                    ExitCode::USR_ILLEGAL_STATE,
-                    "error creating fund cross-message",
-                )
-            })?;
+            let mut f_msg = CrossMsg {
+                msg: StorableMsg::new_fund_msg(&params, &sig_addr, value).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::USR_ILLEGAL_STATE,
+                        "error creating fund cross-message",
+                    )
+                })?,
+            };
             // Commit top-down message.
             st.commit_topdown_msg(rt.store(), &mut f_msg).map_err(|e| {
                 e.downcast_default(
@@ -511,13 +514,15 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             // Create release message
-            let r_msg = StorableMsg::new_release_msg(&st.network_name, &sig_addr, value, st.nonce)
-                .map_err(|e| {
-                    e.downcast_default(
-                        ExitCode::USR_ILLEGAL_STATE,
-                        "error creating release cross-message",
-                    )
-                })?;
+            let r_msg = CrossMsg {
+                msg: StorableMsg::new_release_msg(&st.network_name, &sig_addr, value, st.nonce)
+                    .map_err(|e| {
+                        e.downcast_default(
+                            ExitCode::USR_ILLEGAL_STATE,
+                            "error creating release cross-message",
+                        )
+                    })?,
+            };
 
             // Commit bottom-up message.
             st.commit_bottomup_msg(rt.store(), &r_msg, rt.curr_epoch())
@@ -556,7 +561,10 @@ impl Actor {
                 "no destination for cross-message explicitly set"
             ));
         }
-        let mut msg = params.msg.clone();
+        let CrossMsgParams {
+            mut cross_msg,
+            destination,
+        } = params;
         let mut tp = IPCMsgType::Unknown;
 
         // FIXME: Only supporting cross-messages initiated by signable addresses for
@@ -564,39 +572,41 @@ impl Actor {
         let sig_addr = resolve_secp_bls(rt, rt.message().caller())?;
 
         rt.transaction(|st: &mut State, rt| {
-            if params.destination == st.network_name {
+            if destination == st.network_name {
                 return Err(actor_error!(
-                illegal_argument,
-                "destination is the current network, you are better off with a good ol' message, no cross needed"
-            ));
+                    illegal_argument,
+                    "destination is the current network, you are better off with a good ol' message, no cross needed"
+                ));
             }
             // we disregard the to of the message. the caller is the one set as the from of the
             // message.
-            msg.to = match IPCAddress::new_from_ipc(&params.destination, &msg.to) {
+            let msg = &mut cross_msg.msg;
+            msg.to = match IPCAddress::new_from_ipc(&destination, &msg.to) {
                 Ok(addr) => addr,
                 Err(_) => {
                     return Err(actor_error!(
-                illegal_argument,
-                "error setting IPC address in cross-msg to param"
-            ));
+                        illegal_argument,
+                        "error setting IPC address in cross-msg to param"
+                    ));
                 }
             };
             msg.from = match IPCAddress::new(&st.network_name, &sig_addr) {
                 Ok(addr) => addr,
                 Err(_) => {
                     return Err(actor_error!(
-                illegal_argument,
-                "error setting IPC address in cross-msg from param"
-            ));
+                        illegal_argument,
+                        "error setting IPC address in cross-msg from param"
+                    ));
                 }
             };
-            tp = st.send_cross(rt.store(), &mut msg, rt.curr_epoch()).map_err(|e| {
+            tp = st.send_cross(rt.store(), &mut cross_msg, rt.curr_epoch()).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "error committing cross message")
             })?;
 
             Ok(())
         })?;
 
+        let msg = cross_msg.msg;
         if tp == IPCMsgType::BottomUp && msg.value > TokenAmount::zero() {
             rt.send(
                 *BURNT_FUNDS_ACTOR_ADDR,
@@ -629,8 +639,9 @@ impl Actor {
         // picking up the whole state. Is it more efficient in terms of performance and
         // gas usage to check how to apply the message (b-u or t-p) inside rt.transaction?
         let st: State = rt.state()?;
-        let mut msg = params.msg;
-        let rto = match msg.to.raw_addr() {
+        let ApplyMsgParams { mut cross_msg } = params;
+
+        let rto = match cross_msg.msg.to.raw_addr() {
             Ok(to) => to,
             Err(_) => {
                 return Err(actor_error!(
@@ -639,7 +650,7 @@ impl Actor {
                 ));
             }
         };
-        let sto = match msg.to.subnet() {
+        let sto = match cross_msg.msg.to.subnet() {
             Ok(to) => to,
             Err(_) => {
                 return Err(actor_error!(
@@ -648,37 +659,38 @@ impl Actor {
                 ));
             }
         };
-        match msg.apply_type(&st.network_name) {
+        match cross_msg.msg.apply_type(&st.network_name) {
             Ok(IPCMsgType::BottomUp) => {
                 // perform state transition
                 rt.transaction(|st: &mut State, rt| {
-                    st.bottomup_state_transition(&msg).map_err(|e| {
+                    st.bottomup_state_transition(&cross_msg.msg).map_err(|e| {
                         e.downcast_default(
                             ExitCode::USR_ILLEGAL_STATE,
                             "failed applying bottomup message",
                         )
                     })?;
                     if sto != st.network_name {
-                        st.commit_topdown_msg(rt.store(), &mut msg).map_err(|e| {
-                            e.downcast_default(
-                                ExitCode::USR_ILLEGAL_STATE,
-                                "error committing topdown messages",
-                            )
-                        })?;
+                        st.commit_topdown_msg(rt.store(), &mut cross_msg)
+                            .map_err(|e| {
+                                e.downcast_default(
+                                    ExitCode::USR_ILLEGAL_STATE,
+                                    "error committing topdown messages",
+                                )
+                            })?;
                     }
                     Ok(())
                 })?;
                 // if directed to current network, execute message.
                 if sto == st.network_name {
                     // FIXME: Should we handle return in some way?
-                    let _ = rt.send(rto, msg.method, msg.params, msg.value)?;
+                    let _ = cross_msg.send(rt, rto)?;
                 }
             }
             Ok(IPCMsgType::TopDown) => {
                 // Mint funds for SCA so it can direct them accordingly as part of the message.
                 let params = ext::reward::FundingParams {
                     addr: *SCA_ACTOR_ADDR,
-                    value: msg.value.clone(),
+                    value: cross_msg.msg.value.clone(),
                 };
                 rt.send(
                     *REWARD_ACTOR_ADDR,
@@ -689,7 +701,7 @@ impl Actor {
 
                 rt.transaction(|st: &mut State, rt| {
                     // perform nonce state transition
-                    if st.applied_topdown_nonce != msg.nonce {
+                    if st.applied_topdown_nonce != cross_msg.msg.nonce {
                         return Err(actor_error!(
                             illegal_state,
                             "the top-down message being applied doesn't hold the subsequent nonce"
@@ -698,12 +710,13 @@ impl Actor {
                     st.applied_topdown_nonce += 1;
                     // if not directed to subnet go down.
                     if sto != st.network_name {
-                        st.commit_topdown_msg(rt.store(), &mut msg).map_err(|e| {
-                            e.downcast_default(
-                                ExitCode::USR_ILLEGAL_STATE,
-                                "error committing top-down message while applying it",
-                            )
-                        })?;
+                        st.commit_topdown_msg(rt.store(), &mut cross_msg)
+                            .map_err(|e| {
+                                e.downcast_default(
+                                    ExitCode::USR_ILLEGAL_STATE,
+                                    "error committing top-down message while applying it",
+                                )
+                            })?;
                     }
                     Ok(())
                 })?;
@@ -711,7 +724,7 @@ impl Actor {
                 // if directed to the current network propagate the message
                 if sto == st.network_name {
                     // FIXME: Should we handle return in some way?
-                    let _ = rt.send(rto, msg.method, msg.params, msg.value)?;
+                    let _ = cross_msg.send(rt, rto)?;
                 }
             }
             _ => {

--- a/src/subnet.rs
+++ b/src/subnet.rs
@@ -10,7 +10,7 @@ use crate::subnet_id::SubnetID;
 use crate::CROSSMSG_AMT_BITWIDTH;
 
 use super::checkpoint::*;
-use super::cross::StorableMsg;
+use super::cross::CrossMsg;
 use super::state::State;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize, Serialize)]
@@ -25,7 +25,7 @@ pub enum Status {
 pub struct Subnet {
     pub id: SubnetID,
     pub stake: TokenAmount,
-    pub top_down_msgs: TCid<TAmt<StorableMsg, CROSSMSG_AMT_BITWIDTH>>,
+    pub top_down_msgs: TCid<TAmt<CrossMsg, CROSSMSG_AMT_BITWIDTH>>,
     pub nonce: u64,
     pub circ_supply: TokenAmount,
     pub status: Status,
@@ -57,11 +57,12 @@ impl Subnet {
     pub(crate) fn store_topdown_msg<BS: Blockstore>(
         &mut self,
         store: &BS,
-        msg: &StorableMsg,
+        cross_msg: &CrossMsg,
     ) -> anyhow::Result<()> {
+        let msg = &cross_msg.msg;
         self.top_down_msgs.update(store, |crossmsgs| {
             crossmsgs
-                .set(msg.nonce, msg.clone())
+                .set(msg.nonce, cross_msg.clone())
                 .map_err(|e| anyhow!("failed to set crossmsg meta array: {:?}", e))
         })
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,8 @@ use fvm_shared::econ::TokenAmount;
 use serde::{Deserialize, Serialize};
 
 use crate::checkpoint::{Checkpoint, CrossMsgMeta};
+use crate::cross::CrossMsg;
 use crate::subnet_id::SubnetID;
-use crate::StorableMsg;
 
 pub const CROSSMSG_AMT_BITWIDTH: u32 = 3;
 pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
@@ -14,7 +14,7 @@ pub const MAX_NONCE: u64 = u64::MAX;
 pub const MIN_COLLATERAL_AMOUNT: u64 = 10_u64.pow(18);
 
 pub type CrossMsgMetaArray<'bs, BS> = Array<'bs, CrossMsgMeta, BS>;
-pub type CrossMsgArray<'bs, BS> = Array<'bs, StorableMsg, BS>;
+pub type CrossMsgArray<'bs, BS> = Array<'bs, CrossMsg, BS>;
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ConstructorParams {
@@ -34,13 +34,13 @@ pub struct CheckpointParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct CrossMsgParams {
-    pub msg: StorableMsg,
+    pub cross_msg: CrossMsg,
     pub destination: SubnetID,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct ApplyMsgParams {
-    pub msg: StorableMsg,
+    pub cross_msg: CrossMsg,
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,11 @@ pub struct CrossMsgParams {
     pub destination: SubnetID,
 }
 
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct ApplyMsgParams {
+    pub msg: StorableMsg,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ConstructorParams;


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

This pull request adds support for opt-in wrapped cross-net message delivery. The new delivery method allows the destination actor examine original cross-net message as passed to `ApplyMessage` method of the IPC gateway actor, i.e. to determine the full IPC address of the message's source actor.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->


## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->


