### PR TITLE
kick off ipc address refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "v3.0.0", features = ["fil-actor"] }
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "v3.0.0"}
+fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
 fvm_shared = { version = "3.0.0-alpha.5", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
@@ -35,7 +35,6 @@ unsigned-varint = "0.7.1"
 hex = "0.4.3"
 
 [dev-dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "v3.0.0", features = ["fil-actor", "test_utils"] }
 base64 = "0.13.1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
+hex = "0.4.3"
 
 [dev-dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "v3.0.0", features = ["fil-actor", "test_utils"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
-hex = "0.4.3"
 
 [dev-dependencies]
 base64 = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ipc_gateway"
 description = "Subnet Coordinator Actor (SCA) for IPC"
-version = "9.0.0-alpha.1"
+version = "0.0.1"
 license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2018"
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fvm_shared = { version = "3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.12", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,16 +1,12 @@
-use crate::error::Error;
 use crate::SubnetID;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::fmt::Formatter;
 use std::str::FromStr;
-
-/// Maximum length for an address payload determined by
-/// the maximum size of the IPC address.
-const MAX_ADDRESS_LEN: usize = 54;
+use fil_actors_runtime::cbor;
+use fvm_ipld_encoding::RawBytes;
+use crate::error::Error;
 
 // The default actor id namespace for IPC addresses
 lazy_static! {
@@ -19,98 +15,67 @@ lazy_static! {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub struct IPCAddress {
-    inner: Address,
-}
-
-impl fmt::Display for IPCAddress {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
+    subnet_id: SubnetID,
+    raw_address: Address
 }
 
 impl IPCAddress {
     /// Generates new address using ID protocol
-    pub const fn new_id(id: u64) -> Self {
+    pub fn new_id(id: u64) -> Self {
+        let d = SubnetID::default();
         Self {
-            inner: Address::new_id(id),
+            subnet_id: d,
+            raw_address: Address::new_id(id),
         }
     }
 
     /// Generates new IPC address
     pub fn new(sn: &SubnetID, addr: &Address) -> Result<Self, Error> {
-        let sn = sn.to_bytes();
-        let addr = addr.to_bytes();
-        let sn_size_vec = to_leb_bytes(sn.len() as u64)?;
-        let sn_size: &[u8] = sn_size_vec.as_ref();
-        let addr_size_vec = to_leb_bytes(addr.len() as u64)?;
-        let addr_size: &[u8] = addr_size_vec.as_ref();
-        let sp = [sn_size, addr_size, sn.as_slice(), addr.as_slice()].concat();
-        // include in fixed-length container
-        let mut key = [0u8; MAX_ADDRESS_LEN];
-        key[..sp.len()].copy_from_slice(sp.as_slice());
         Ok(Self {
-            inner: Address::new_delegated(*DEFAULT_IPC_ACTOR_NAMESPACE_ID, &key)?,
+            subnet_id: sn.clone(),
+            raw_address: *addr
         })
     }
 
     /// Generates new IPC address
     pub fn new_from_ipc(sn: &SubnetID, addr: &Self) -> Result<Self, Error> {
-        let sn = sn.to_bytes();
-        let addr = addr.to_bytes();
-        let sn_size_vec = to_leb_bytes(sn.len() as u64)?;
-        let sn_size: &[u8] = sn_size_vec.as_ref();
-        let addr_size_vec = to_leb_bytes(addr.len() as u64)?;
-        let addr_size: &[u8] = addr_size_vec.as_ref();
-        let sp = [sn_size, addr_size, sn.as_slice(), addr.as_slice()].concat();
-        // include in fixed-length container
-        let mut key = [0u8; MAX_ADDRESS_LEN];
-        key[..sp.len()].copy_from_slice(sp.as_slice());
         Ok(Self {
-            inner: Address::new_delegated(*DEFAULT_IPC_ACTOR_NAMESPACE_ID, &key)?,
+            subnet_id: sn.clone(),
+            raw_address: addr.raw_address
         })
     }
 
     /// Returns subnets of a IPC address
     pub fn subnet(&self) -> Result<SubnetID, Error> {
-        let bz = self.inner.payload().to_raw_bytes();
-        let sn_size = from_leb_bytes(&[bz[0]]).unwrap() as usize;
-        let s =
-            String::from_utf8(bz[2..sn_size + 2].to_vec()).map_err(|_| Error::InvalidIPCAddr)?;
-        SubnetID::from_str(&s).map_err(|_| Error::InvalidIPCAddr)
+        Ok(self.subnet_id.clone())
     }
 
     /// Returns the raw address of a IPC address (without subnet context)
     pub fn raw_addr(&self) -> Result<Address, Error> {
-        let bz = self.inner.payload().to_raw_bytes();
-        let sn_size = from_leb_bytes(&[bz[0]]).unwrap() as usize;
-        Ok(Address::from_bytes(&bz[2 + sn_size..])?)
+        Ok(self.raw_address)
     }
 
-    /// Returns encoded bytes of Address
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
+  /// Returns encoded bytes of Address
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        Ok(cbor::serialize(self, "ipc-address")?.to_vec())
     }
-}
 
-pub(crate) fn to_leb_bytes(id: u64) -> Result<Vec<u8>, Error> {
-    // write id to buffer in leb128 format
-    Ok(unsigned_varint::encode::u64(id, &mut unsigned_varint::encode::u64_buffer()).into())
-}
-
-pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
-    // write id to buffer in leb128 format
-    let (id, remaining) = unsigned_varint::decode::u64(bz)?;
-    if !remaining.is_empty() {
-        return Err(Error::InvalidPayload);
+    pub fn from_bytes(bz: &[u8]) -> Result<Self, Error> {
+        let i: Self = cbor::deserialize(&RawBytes::new(bz.to_vec()), "ipc-address")?;
+        Ok(i)
     }
-    Ok(id)
+
+    pub fn to_string(&self) -> Result<String, Error> {
+        let bytes = self.to_bytes()?;
+        Ok(hex::encode(bytes))
+    }
 }
 
 impl FromStr for IPCAddress {
     type Err = Error;
 
     fn from_str(addr: &str) -> Result<Self, Error> {
-        let inner = Address::from_str(addr)?;
-        Ok(Self { inner })
+        let bytes = hex::decode(addr)?;
+        Self::from_bytes(&bytes)
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -71,8 +71,8 @@ impl IPCAddress {
         // determined which is the start of Address
         Ok(format!(
             "{}-{}",
-            self.subnet_id.to_string(),
-            self.raw_address.to_string()
+            self.subnet_id,
+            self.raw_address
         ))
     }
 }
@@ -81,7 +81,7 @@ impl FromStr for IPCAddress {
     type Err = Error;
 
     fn from_str(addr: &str) -> Result<Self, Error> {
-        let r: Vec<&str> = addr.split("-").collect();
+        let r: Vec<&str> = addr.split('-').collect();
         if r.len() != 2 {
             Err(Error::InvalidIPCAddr)
         } else {

--- a/src/address.rs
+++ b/src/address.rs
@@ -66,6 +66,9 @@ impl IPCAddress {
     }
 
     pub fn to_string(&self) -> Result<String, Error> {
+        // `-` is used as delimiter instead of `/`
+        // `/` is harder to parse as `SubnetId` contains `/`, which makes it difficult to
+        // determined which is the start of Address
         Ok(format!(
             "{}-{}",
             self.subnet_id.to_string(),

--- a/src/address.rs
+++ b/src/address.rs
@@ -69,11 +69,7 @@ impl IPCAddress {
         // `-` is used as delimiter instead of `/`
         // `/` is harder to parse as `SubnetId` contains `/`, which makes it difficult to
         // determined which is the start of Address
-        Ok(format!(
-            "{}-{}",
-            self.subnet_id,
-            self.raw_address
-        ))
+        Ok(format!("{}-{}", self.subnet_id, self.raw_address))
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -66,7 +66,11 @@ impl IPCAddress {
     }
 
     pub fn to_string(&self) -> Result<String, Error> {
-        Ok(format!("{}-{}", self.subnet_id.to_string(), self.raw_address.to_string()))
+        Ok(format!(
+            "{}-{}",
+            self.subnet_id.to_string(),
+            self.raw_address.to_string()
+        ))
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -66,8 +66,7 @@ impl IPCAddress {
     }
 
     pub fn to_string(&self) -> Result<String, Error> {
-        let bytes = self.to_bytes()?;
-        Ok(hex::encode(bytes))
+        Ok(format!("{}-{}", self.subnet_id.to_string(), self.raw_address.to_string()))
     }
 }
 
@@ -75,7 +74,14 @@ impl FromStr for IPCAddress {
     type Err = Error;
 
     fn from_str(addr: &str) -> Result<Self, Error> {
-        let bytes = hex::decode(addr)?;
-        Self::from_bytes(&bytes)
+        let r: Vec<&str> = addr.split("-").collect();
+        if r.len() != 2 {
+            Err(Error::InvalidIPCAddr)
+        } else {
+            Ok(Self {
+                raw_address: Address::from_str(r[1])?,
+                subnet_id: SubnetID::from_str(r[0])?,
+            })
+        }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,12 +1,12 @@
+use crate::error::Error;
 use crate::SubnetID;
+use fil_actors_runtime::cbor;
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use fil_actors_runtime::cbor;
-use fvm_ipld_encoding::RawBytes;
-use crate::error::Error;
 
 // The default actor id namespace for IPC addresses
 lazy_static! {
@@ -16,7 +16,7 @@ lazy_static! {
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub struct IPCAddress {
     subnet_id: SubnetID,
-    raw_address: Address
+    raw_address: Address,
 }
 
 impl IPCAddress {
@@ -33,7 +33,7 @@ impl IPCAddress {
     pub fn new(sn: &SubnetID, addr: &Address) -> Result<Self, Error> {
         Ok(Self {
             subnet_id: sn.clone(),
-            raw_address: *addr
+            raw_address: *addr,
         })
     }
 
@@ -41,7 +41,7 @@ impl IPCAddress {
     pub fn new_from_ipc(sn: &SubnetID, addr: &Self) -> Result<Self, Error> {
         Ok(Self {
             subnet_id: sn.clone(),
-            raw_address: addr.raw_address
+            raw_address: addr.raw_address,
         })
     }
 
@@ -55,7 +55,7 @@ impl IPCAddress {
         Ok(self.raw_address)
     }
 
-  /// Returns encoded bytes of Address
+    /// Returns encoded bytes of Address
     pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         Ok(cbor::serialize(self, "ipc-address")?.to_vec())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
+use fil_actors_runtime::ActorError;
+use hex::FromHexError;
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq, Error)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
     #[error("invalid address payload")]
     InvalidPayload,
@@ -14,6 +16,21 @@ pub enum Error {
     UnsignedVariantDecodeError(unsigned_varint::decode::Error),
     #[error("unknown network")]
     UnknownNetwork,
+    #[error("hex encoding error")]
+    HexEncoding(FromHexError),
+    #[error("actor error")]
+    Actor(ActorError)
+}
+
+impl From<ActorError> for Error {
+    fn from(e: ActorError) -> Self {
+        Self::Actor(e)
+    }
+}
+impl From<FromHexError> for Error {
+    fn from(e: FromHexError) -> Self {
+        Self::HexEncoding(e)
+    }
 }
 
 impl From<fvm_shared::address::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 use fil_actors_runtime::ActorError;
-use hex::FromHexError;
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, Error)]
 pub enum Error {
     #[error("invalid address payload")]
     InvalidPayload,
@@ -16,8 +15,6 @@ pub enum Error {
     UnsignedVariantDecodeError(unsigned_varint::decode::Error),
     #[error("unknown network")]
     UnknownNetwork,
-    #[error("hex encoding error")]
-    HexEncoding(FromHexError),
     #[error("actor error")]
     Actor(ActorError),
 }
@@ -25,11 +22,6 @@ pub enum Error {
 impl From<ActorError> for Error {
     fn from(e: ActorError) -> Self {
         Self::Actor(e)
-    }
-}
-impl From<FromHexError> for Error {
-    fn from(e: FromHexError) -> Self {
-        Self::HexEncoding(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     #[error("hex encoding error")]
     HexEncoding(FromHexError),
     #[error("actor error")]
-    Actor(ActorError)
+    Actor(ActorError),
 }
 
 impl From<ActorError> for Error {

--- a/src/subnet_id.rs
+++ b/src/subnet_id.rs
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(root_sub, rootnet);
     }
 
-    // TODO: temporarily disabled for compilation and comply with Delegated Address
+    // // TODO: temporarily disabled for compilation and comply with Delegated Address
     // #[test]
     // fn test_IPC_address() {
     //     let act = Address::new_id(1001);
@@ -257,7 +257,7 @@ mod tests {
     fn test_ipc_from_str() {
         let sub_id = SubnetID::new(&ROOTNET_ID.clone(), Address::new_id(100));
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
-        let st = addr.to_string();
+        let st = addr.to_string().unwrap();
         let addr_out = IPCAddress::from_str(&st).unwrap();
         assert_eq!(addr, addr_out);
     }

--- a/src/subnet_id.rs
+++ b/src/subnet_id.rs
@@ -258,6 +258,7 @@ mod tests {
         let sub_id = SubnetID::new(&ROOTNET_ID.clone(), Address::new_id(100));
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_string().unwrap();
+        println!("{}", st);
         let addr_out = IPCAddress::from_str(&st).unwrap();
         assert_eq!(addr, addr_out);
     }

--- a/src/subnet_id.rs
+++ b/src/subnet_id.rs
@@ -258,7 +258,6 @@ mod tests {
         let sub_id = SubnetID::new(&ROOTNET_ID.clone(), Address::new_id(100));
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_string().unwrap();
-        println!("{}", st);
         let addr_out = IPCAddress::from_str(&st).unwrap();
         assert_eq!(addr, addr_out);
     }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->
Refactor `IPCAddress` to be a wrapper of both `SubnetId` and `Address`.

- Use `cbor` to convert to and from bytes
- Use `hex` to convert to and from String
Update on 23/11/2022: 
- Fixed IPCAddress::to_string and from_str based on the comments. Used "-" instead, reason posted in code as comment.
- Fixed dependency conflicts and `cicd` pipeline

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test
```
